### PR TITLE
Update navigation to disable Experience and Contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pnpm dev
 
 ## Current Status
 
-Currently displaying Hero, About, and Projects sections. Experience, Contact, and Navigation sections are implemented but temporarily disabled while under development.
+Currently displaying Hero, About, and Projects sections with active navigation. Experience and Contact sections are implemented but temporarily disabled in navigation while under development.
 
 ## Documentation
 

--- a/config/portfolio.ts
+++ b/config/portfolio.ts
@@ -30,9 +30,9 @@ export const portfolioConfig: PortfolioConfig = {
 	// Navigation
 	navigation: [
 		{ name: "About", href: "#about" },
-		{ name: "Experience", href: "#experience" },
+		// { name: "Experience", href: "#experience" },
 		{ name: "Work", href: "#work" },
-		{ name: "Contact", href: "#contact" },
+		// { name: "Contact", href: "#contact" },
 	],
 
 	// About Section


### PR DESCRIPTION
Commented out Experience and Contact sections in the navigation array in portfolio config. Updated README to clarify that navigation is active for displayed sections, while Experience and Contact are implemented but not currently shown in navigation.